### PR TITLE
ci: add github workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,47 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build project then run tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        profile:
+          - dev
+          - release
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        run: rustup update stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Build project with "${{ matrix.profile }}" profile
+        run:
+          cargo build --profile "${{ matrix.profile }}"
+
+      - name: Generate code coverage
+        run: |
+          cargo llvm-cov \
+            --profile "${{ matrix.profile }}" \
+            --all-features \
+            --workspace \
+            --lcov \
+            --output-path coverage.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This commit add a github workflow `Checks` to

1. Run cargo test when pull request or the master branch updated;
2. Generate coverage data using cargo-llvm-cov and upload it to codecov.
